### PR TITLE
Fixed Gromacs ABF-Exemple 1 walker json-inputfile.

### DIFF
--- a/Examples/User/ABF/Example_AlanineDipeptide/ABF_ADP_Gromacs_Example/ABF_ADP_1walker.json
+++ b/Examples/User/ABF/Example_AlanineDipeptide/ABF_ADP_Gromacs_Example/ABF_ADP_1walker.json
@@ -1,5 +1,5 @@
 {
-    "inputfile" : "ABF_ADP_Gromacs_Example/example_adp.tpr",
+    "inputfile" : "example_adp.tpr",
     "driver" : [        
         {
             "number processors" : 1,
@@ -11,7 +11,7 @@
                 {
                     "periodic": true,
                     "type": "Torsional",
-                    "atom ids": [
+                    "atom_ids": [
                         5,
                         7,
                         9,
@@ -21,7 +21,7 @@
                 {
                     "periodic": true,
                     "type": "Torsional",
-                    "atom ids": [
+                    "atom_ids": [
                         7,
                         9,
                         15,

--- a/Examples/User/ABF/Example_AlanineDipeptide/ABF_ADP_Gromacs_Example/ABF_ADP_8walkers.json
+++ b/Examples/User/ABF/Example_AlanineDipeptide/ABF_ADP_Gromacs_Example/ABF_ADP_8walkers.json
@@ -1,5 +1,5 @@
 {
-    "inputfile" : "ABF_ADP_Gromacs_Example/example_adp.tpr",
+    "inputfile" : "example_adp.tpr",
     "driver" : [        
         {
             "number processors" : 1,
@@ -53,7 +53,7 @@
                 {
                     "periodic": true,
                     "type": "Torsional",
-                    "atom ids": [
+                    "atom_ids": [
                         5,
                         7,
                         9,
@@ -63,7 +63,7 @@
                 {
                     "periodic": true,
                     "type": "Torsional",
-                    "atom ids": [
+                    "atom_ids": [
                         7,
                         9,
                         15,


### PR DESCRIPTION
Example ABF for Gromacs didn't work due to invalid property ("atom id" instead of "atom_id").