### PR TITLE
Wrap HOOMD Force Computes as collective variables

### DIFF
--- a/hooks/hoomd/HOOMDHook.cpp
+++ b/hooks/hoomd/HOOMDHook.cpp
@@ -6,7 +6,7 @@
 using namespace SSAGES;
 
 HOOMDHook::HOOMDHook() :
-Hook(), HalfStepHook()
+Hook(), HalfStepHook(), timestep_(0)
 {
   std::cerr << "Installing SSAGES HOOMD-blue hook." << std::endl;
 }

--- a/hooks/hoomd/HOOMDHook.h
+++ b/hooks/hoomd/HOOMDHook.h
@@ -2,11 +2,14 @@
 #define SSAGES_HOOMD_HOOK_H
 
 #include "Hook.h"
+#include "CVs/CVManager.h"
+
 #include "hoomd/ExecutionConfiguration.h"
 #include "hoomd/SystemDefinition.h"
 #include "hoomd/HalfStepHook.h"
 #include "hoomd/ComputeThermo.h"
 
+#include "hoomd/extern/pybind/include/pybind11/pybind11.h"
 
 // SSAGES Hook class for HOOMD
 class HOOMDHook : public SSAGES::Hook, public HalfStepHook
@@ -21,6 +24,9 @@ class HOOMDHook : public SSAGES::Hook, public HalfStepHook
         // HOOMD ComputeThermo
         std::shared_ptr<ComputeThermo> thermo_;
 
+        // Python interpreter scope
+        pybind11::object scope_;
+
     protected:
         // Implementation of the SyncToEngine interface.
         void SyncToEngine() override;
@@ -31,11 +37,34 @@ class HOOMDHook : public SSAGES::Hook, public HalfStepHook
     public:
         HOOMDHook();
 
+        //! Pre-simulation hook
+        /*!
+         * This should be called at the appropriate
+         * time by the Hook implementation.
+         */
+        virtual void PreSimulationHook() override
+        {
+            // call base class method
+            Hook::PreSimulationHook();
+
+            // Set simulation engine hook on CVs
+            for(auto& cv : cvmanager_->GetCVs())
+            {
+                cv->SetHook(*this);
+            }
+        }
+
         // Sets SystemDefinition to enable particle data access
-        void setSystemDefinition(std::shared_ptr<SystemDefinition> sysdef)
+        void setSystemDefinition(std::shared_ptr<SystemDefinition> sysdef) override
         {
             sysdef_ = sysdef;
         }
+
+        // Get the SystemDefinition
+        std::shared_ptr<SystemDefinition> getSystemDefinition()
+            {
+            return sysdef_;
+            }
 
         // Sets ComputeThermo to enable temperature and energy computation
         void setComputeThermo(std::shared_ptr<ComputeThermo> thermo)
@@ -44,7 +73,25 @@ class HOOMDHook : public SSAGES::Hook, public HalfStepHook
         }
 
         // Synchronize snapshot with SSAGES after computing forces
-        void update(unsigned int timestep);
+        void update(unsigned int timestep) override;
+
+        // Return the current time step
+        unsigned int getTimeStep()
+            {
+            return timestep_;
+            }
+
+        // Set the python interpreter scope
+        void setPyScope(pybind11::object scope)
+            {
+            scope_ = scope;
+            }
+
+        // Set the python interpreter scope
+        pybind11::object getPyScope()
+            {
+            return scope_;
+            }
 
         ~HOOMDHook();
 };

--- a/hooks/hoomd/HOOMDWrapCV.h
+++ b/hooks/hoomd/HOOMDWrapCV.h
@@ -1,0 +1,172 @@
+/**
+ * This file is part of
+ * SSAGES - Suite for Advanced Generalized Ensemble Simulations
+ *
+ * Copyright 2016 Yamil Colon <yamilcolon2015@u.northwestern.edu>
+ *                Hythem Sidky <hsidky@nd.edu>
+ *
+ * SSAGES is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SSAGES is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with SSAGES.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once 
+
+#include "CVs/CollectiveVariable.h"
+#include "Validator/ObjectRequirement.h"
+#include "Drivers/DriverException.h"
+#include "Snapshot.h"
+#include "schema.h"
+
+#include "hoomd/ForceCompute.h"
+
+namespace SSAGES
+{
+    //! Collective variable to calculate angle.
+    class HOOMDWrapCV : public CollectiveVariable
+    {
+    private:
+        //! The ForceCompute we wrap
+        std::shared_ptr<ForceCompute> fc_;
+
+        //! A reference to the HOOMD hook
+        HOOMDHook& hook_;
+
+    public:
+
+        //! Constructor.
+        /*!
+         * \param fc The force compute to wrap
+         *
+         * Wrap a HOOMD ForceCompute into a CollectiveVariable
+         *
+         * \todo Bounds needs to be an input and periodic boundary conditions
+         */
+        HOOMDWrapCV(std::shared_ptr<ForceCompute> fc);
+        fc_(fc)
+        { }
+
+        //! Initialize necessary variables.
+        /*!
+         * \param snapshot Current simulation snapshot.
+         */
+        void Initialize(const Snapshot& snapshot) override
+        {
+        #if 0
+        using std::to_string;
+
+        std::vector<int> found;
+        snapshot.GetLocalIndices(atomids_, &found);
+        int nfound = found.size();
+        MPI_Allreduce(MPI_IN_PLACE, &nfound, 1, MPI_INT, MPI_SUM, snapshot.GetCommunicator());
+
+        if(nfound != 3)
+            throw BuildException({
+                "TorsionalCV: Expected to find " + 
+                to_string(3) + 
+                " atoms, but only found " + 
+                to_string(nfound) + "."
+            });	
+        #endif
+        }
+
+        //! This sets a reference to the simulation engine hook.
+        /*!
+         * This method is called during initialization and can be used by the CV
+         * to access engine-specific data structures.
+         */
+        virtual void SetHook(const HOOMDHook& hook)
+            {
+            hook_ = hook;
+            }
+
+        //! Evaluate the CV.
+        /*!
+        * \param snapshot Current simulation snapshot.
+        */
+        void Evaluate(const Snapshot& snapshot) override
+        {
+            // evaluate the underlying ForceCompute
+            fc_->compute(hook_.getTimeStep());
+
+            // reduce CV
+            val_ = fc->calcEnergySum();
+        }
+
+        //! Compute the particle forces and virial by scaling the gradient with a constant
+        /*!
+         * \param bias The constant scaling factor to apply to all particle forces
+         * \param snapshot The snapshot that contains the forces
+         *
+         */
+        virtual void ApplyBias(double bias, const Snapshot& snapshot) const
+        {
+            // evaluate the underlying ForceCompute (only if necessary)
+            fc_->compute(hook_.getTimeStep());
+
+            ArrayHandle<Scalar4> h_force(fc_->getForce(), access_location::host, access_mode::readwrite);
+            ArrayHandle<Scalar> h_virial(fc_->getVirial(), access_location::host, access_mode::readwrite);
+            ArrayHandle<Scalar4> h_torque(fc_->getTorque(), access_location::host, access_mode::readwrite);
+
+            unsigned int virial_pitch = fc_->getVirial().getPitch();
+
+            auto pdata = hook_->getSystemDefinition()->getParticleData();
+            unsigned int n = pdata->getN();
+
+            // multiply particle forces with bias
+            for (unsigned int i = 0; i < n; ++i)
+                h_force.data[i] *= bias;
+
+            for (unsigned int j = 0; j < 6; ++j)
+                for (unsigned int i = 0; i < n; ++i)
+                    h_virial.data[j*virial_pitch + i] *= bias;
+
+            #if 0
+            // currently cannot set the external virial
+            for (unsigned int j = 0; j < 6; ++j)
+                fc_->setExternalVirial(j,fc_->getExternalVirial(j)*bias);
+            #endif
+        }
+
+        //! \copydoc CollectiveVariable::BuildCV()
+        static HOOMDWrapCV* Build(const Json::Value& json, const std::string& path)
+        {
+        Json::ObjectRequirement validator;
+        Json::Value schema;
+        Json::CharReaderBuilder rbuilder;
+        Json::CharReader* reader = rbuilder.newCharReader();
+
+        reader->parse(JsonSchema::HOOMDWrapCV.c_str(),
+                      JsonSchema::HOOMDWrapCV.c_str() + JsonSchema::HOOMDWrapCV.size(),
+                      &schema, NULL);
+        validator.Parse(schema, path);
+
+        // Validate inputs.
+        validator.Validate(json, path);
+        if(validator.HasErrors())
+            throw BuildException(validator.GetErrors());
+
+        std::vector<int> atomids;
+        auto force = json["force"].asString();
+
+        std::shared_ptr<ForceCompute> fc = context.attr(force).attr("cpp_force");
+        return new HOOMDWrapCV(fc);
+        }
+
+        //! Returns true if this CV can modify the particle forces in the snapshot
+        virtual bool ModifiesParticleForces() const
+        {
+        return false;
+        }
+
+
+    };
+}

--- a/schema/CVs/HOOMD.cv.json
+++ b/schema/CVs/HOOMD.cv.json
@@ -1,0 +1,23 @@
+{
+    "type" : "object",
+    "varname" : "HOOMDCV",
+    "properties" : {
+        "type" : {
+            "type" : "string",
+            "enum" : ["HOOMDCV"]
+        },
+        "force" : {
+            "type" : "string"
+        },
+        "bounds" : {
+        "type" : "array",
+        "minItems" : 2,
+        "maxItems" : 2,
+        "items" : {
+            "type" : "number"
+            }
+        }
+    },
+    "required" : ["type", "force"],
+    "additionalProperties" : false
+}

--- a/src/CVs/CollectiveVariable.cpp
+++ b/src/CVs/CollectiveVariable.cpp
@@ -36,6 +36,10 @@
 #include "json/json.h"
 #include <stdexcept>
 
+#ifdef ENABLE_HOOMD
+#include "../../hooks/hoomd/HOOMDWrapCV.h"
+#endif
+
 namespace SSAGES
 {
 	CollectiveVariable* CollectiveVariable::BuildCV(const Json::Value &json, const std::string& path)
@@ -67,6 +71,12 @@ namespace SSAGES
 			return ParallelBetaRMSDCV::Build(json, path);
 		else if (type == "AntiBetaRMSD")
 			return AntiBetaRMSDCV::Build(json, path);
+        else if (type == "HOOMDCV")
+        #ifdef ENABLE_HOOMD
+            return HOOMDWrapCV::Build(json, path);
+        #else
+            throw std::invalid_argument(path + ": HOOMDCV not available. Compile with HOOMD Hook.");
+        #endif
 		else
 			throw std::invalid_argument(path + ": Unknown CV type specified.");
 	}

--- a/src/Hook.h
+++ b/src/Hook.h
@@ -38,10 +38,10 @@ namespace SSAGES
 		//! Vector of event listeners.
 		std::vector<EventListener*> listeners_;
 
-		//! Collective variable manager.
-		class CVManager* cvmanager_;
-
 	protected:
+        //! Collective variable manager.
+        class CVManager* cvmanager_;
+
 		//! Local snapshot.
 		class Snapshot* snapshot_;
 
@@ -94,7 +94,7 @@ namespace SSAGES
 		 * This should be called at the appropriate
 		 * time by the Hook implementation.
 		 */
-		void PreSimulationHook();
+		virtual void PreSimulationHook();
 
 		//! Post-integration hook.
 		/*!

--- a/src/Methods/ABF.h
+++ b/src/Methods/ABF.h
@@ -110,7 +110,7 @@ namespace SSAGES
 		bool massweigh_;
 
 		//! Biases applied to atoms each timestep.	
-		std::vector<Vector3> biases_;
+		std::vector<double> biases_;
 
 		//! Number of CVs in system.
 		unsigned int dim_;

--- a/src/Methods/ANN.cpp
+++ b/src/Methods/ANN.cpp
@@ -145,20 +145,9 @@ namespace SSAGES
 		}
 
 		// Apply bias to atoms. 
-		auto& forces = snapshot->GetForces(); 
-		auto& virial = snapshot->GetVirial();
-
 		for(size_t i = 0; i < cvs.size(); ++i)
 		{
-			auto& grad = cvs[i]->GetGradient();
-			auto& boxgrad = cvs[i]->GetBoxGradient();
-			
-			// Update the forces in snapshot by adding in the force bias from each
-			// CV to each atom based on the gradient of the CV.
-			for (size_t j = 0; j < forces.size(); ++j)
-				forces[j] -= derivatives[i]*grad[j];
-			
-			virial += derivatives[i]*boxgrad;
+            cvs[i]->ApplyBias(derivatives[i], *snapshot);
 		}
 	}
 

--- a/src/Methods/BasisFunc.cpp
+++ b/src/Methods/BasisFunc.cpp
@@ -139,21 +139,10 @@ namespace SSAGES
         }
 
 		// Take each CV and add its biased forces to the atoms using the chain rule
-		auto& forces = snapshot->GetForces();
-        auto& virial = snapshot->GetVirial();
 		for(size_t i = 0; i < cvs.size(); ++i)
-		{
-			auto& grad = cvs[i]->GetGradient();
-            auto& boxgrad = cvs[i]->GetBoxGradient();
-
-			/* Update the forces in snapshot by adding in the force bias from each
-			 *CV to each atom based on the gradient of the CV.
-             */
-			for (size_t j = 0; j < forces.size(); ++j) 
-				forces[j] += bias_grad[i]*grad[j];
-            
-            virial -= bias_grad[i]*boxgrad;
-		}
+        {
+            cvs[i]->ApplyBias(-bias_grad[i],*snapshot);
+        }
 	}
 
 	// Post-simulation hook.

--- a/src/Methods/ElasticBand.cpp
+++ b/src/Methods/ElasticBand.cpp
@@ -29,7 +29,6 @@ namespace SSAGES
 	// Post-integration hook.
 	void ElasticBand::PostIntegration(Snapshot* snapshot, const CVManager& cvmanager)
 	{
-		auto& forces = snapshot->GetForces();
 		auto cvs = cvmanager.GetCVs(cvmask_);
 
 		// Apply umbrella to cvs
@@ -37,16 +36,13 @@ namespace SSAGES
 		{
 			// Get current CV and gradient.
 			auto& cv = cvs[i];
-			auto& grad = cv->GetGradient();
 
 			// Compute dV/dCV.
 			auto diff = cv->GetDifference(centers_[i]);
 			auto D = cvspring_[i] * diff;
 
 			// Update forces.
-			for(size_t j = 0; j < forces.size(); ++j)
-				for(int k = 0; k < forces[j].size(); ++k)
-					forces[j][k] -= D*grad[j][k];
+            cv->ApplyBias(D, *snapshot);
 
 			// If not equilibrating and has evolved enough steps,
 			// generate the gradient

--- a/src/Methods/FiniteTempString.cpp
+++ b/src/Methods/FiniteTempString.cpp
@@ -107,14 +107,12 @@ namespace SSAGES
                     {
                         // Get current cv and gradient
                         auto& cv = cvs[i];
-                        auto& grad = cv->GetGradient();
 
                         // Compute dV/dCV
                         auto D = cvspring_[i]*(cv->GetDifference(centers_[i]));
 
                         // Update forces
-                        for(size_t j = 0; j < forces.size(); j++)
-                                forces[j] -= D*grad[j];
+                        cv->ApplyBias(D,*snapshot);
                     }
                     umbrella_iter_++; //Progress toward checkpoint 
                 }

--- a/src/Methods/Meta.cpp
+++ b/src/Methods/Meta.cpp
@@ -109,21 +109,9 @@ namespace SSAGES
 
 		// Take each CV and add its biased forces to the atoms
 		// using the chain rule.
-		auto& forces = snapshot->GetForces();
-		auto& virial = snapshot->GetVirial();
-
 		for(size_t i = 0; i < cvs.size(); ++i)
 		{
-			auto& grad = cvs[i]->GetGradient();
-			auto& boxgrad = cvs[i]->GetBoxGradient();
-			
-			// Update the forces in snapshot by adding in the force bias from each
-			// CV to each atom based on the gradient of the CV.
-			for (size_t j = 0; j < forces.size(); ++j)
-				for(size_t k = 0; k < 3; ++k)
-					forces[j][k] -= derivatives_[i]*grad[j][k];
-			
-			virial += derivatives_[i]*boxgrad;
+        cvs[i]->ApplyBias(derivatives_[i], *snapshot);
 		}
 	}
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -30,6 +30,7 @@
 #cmakedefine ENABLE_GROMACS
 #cmakedefine ENABLE_QBOX
 #cmakedefine ENABLE_OPENMD
+#cmakedefine ENABLE_HOOMD
 
 #define EXTRA_CONFIG "@EXTRA_CONFIG@"
 


### PR DESCRIPTION
I am opening this PR to solicit input at an early design stage and track progress. The PR aims to eliminate the need to go through snapshots and expensive device host/copies for computing CVs on the GPU, by allowing them to be computed inside the engine and also the forces to be accumulated there.

The minimal information needed to bias a system in a CV is a constant scaling factor applied to all forces, and the value of the CV itself. The new `CollectiveVariable::ApplyBias` method takes care of this. The new collective variable `HOOMDCV` is able to take a user-defined HOOMD `md.force` object and wrap it's C++-side implementation into a SSAGES CV.

At this point, the changes only compile, and are most likely not doing anything sensible. Most important missing bit is to call the `HalfStepHook` *before* HOOMD's `computeNetForce()`, in addition to afterwards (which is currently the case), so as to be able to bias the force before accumulation.

When that is done, the snapshot copying can be optimized out entirely dependent on whether all active CVs have the `modifiesParticleForces()` flag set.