### PR TITLE
Restart ffs

### DIFF
--- a/Examples/User/ForwardFlux/GROMACS/ADP/Template_Input.json
+++ b/Examples/User/ForwardFlux/GROMACS/ADP/Template_Input.json
@@ -34,6 +34,7 @@
 			"nInterfaces" : 5,
 			"computeInitialFlux" : true,
 			"N0Target" : 100,
+			"NLastSuccessful": 100,
 			"outputDirectoryName" : "FFSoutput",
 			"saveTrajectories" : true
 		}

--- a/Examples/User/ForwardFlux/LAMMPS/ADP/Template_Input.json
+++ b/Examples/User/ForwardFlux/LAMMPS/ADP/Template_Input.json
@@ -33,6 +33,7 @@
 			"nInterfaces" : 5,
 			"computeInitialFlux" : true,
 			"N0Target" : 100,
+			"NLastSuccessful": 100,
 			"outputDirectoryName" : "FFSoutput",
 			"saveTrajectories" : true
 		}

--- a/Examples/User/ForwardFlux/LAMMPS/Langevin/Template_Input.json
+++ b/Examples/User/ForwardFlux/LAMMPS/Langevin/Template_Input.json
@@ -17,6 +17,7 @@
 			"interfaces" : [],
 			"nInterfaces" : 5,
 			"N0Target" : 100,
+			"NLastSuccessful": 100,
 			"computeInitialFlux" : true,
 			"outputDirectoryName" : "FFSoutput",
 			"saveTrajectories" : true

--- a/schema/Methods/forwardflux.method.json
+++ b/schema/Methods/forwardflux.method.json
@@ -24,6 +24,10 @@
 			"type" : "integer",
 			"minimum" : 1
 		},
+		"NLastSuccessful" : {
+			"type" : "integer",
+			"minimum" : 1
+		},
 		"trials" : {
 			"type" : "array",
 			"minItems" : 1,

--- a/src/Methods/DirectForwardFlux.cpp
+++ b/src/Methods/DirectForwardFlux.cpp
@@ -287,12 +287,15 @@ namespace SSAGES
 		unsigned int npicks = _M[0];
 		std::vector<unsigned int> picks;
 		picks.resize(npicks);
-		// if the initial flux has already been realized or 
-		//the calculation starts from a non-zero interface (restart)
-		if (initializeQueueFlag)
-			{
-				_N[_current_interface]=_NLastSuccessful;
-			}
+		
+		// if the initial flux has already been realized or
+		// we've got more than _N0Target configurations for zero surface 		
+		if (_current_interface == 0)
+			_N[_current_interface]=_N0Target;
+
+		//if the calculation starts from a non-zero surface (for restart)
+		if (_N[_current_interface] == 0)
+			_N[_current_interface]=_NLastSuccessful;
 
 		if(IsMasterRank(world_))
 		{

--- a/src/Methods/DirectForwardFlux.cpp
+++ b/src/Methods/DirectForwardFlux.cpp
@@ -58,7 +58,7 @@ namespace SSAGES
 		// Else check the FFS interfaces
 		else
 		{
-			CheckForInterfaceCrossings(snapshot, cvmanager);
+			CheckForInterfaceCrossings(snapshot, cvmanager); 
 			//FluxBruteForce(snapshot,cvs);
 		}
 		// Other modes?
@@ -287,10 +287,16 @@ namespace SSAGES
 		unsigned int npicks = _M[0];
 		std::vector<unsigned int> picks;
 		picks.resize(npicks);
+		// if the initial flux has already been realized or 
+		//the calculation starts from a non-zero interface (restart)
+		if (initializeQueueFlag)
+			{
+				_N[_current_interface]=_NLastSuccessful;
+			}
 
 		if(IsMasterRank(world_))
 		{
-			std::uniform_int_distribution<int> distribution(0,_N[0]-1);
+			std::uniform_int_distribution<int> distribution(0,_N[_current_interface]-1);
 		  	for (unsigned int i=0; i < npicks ; i++)
 				picks[i] = distribution(_generator);
 		}
@@ -298,7 +304,7 @@ namespace SSAGES
 
 		//set correct attempt index if a given ID is picked twice
 		std::vector<unsigned int> attempt_count;
-		attempt_count.resize(_N[0],0);
+		attempt_count.resize(_N[_current_interface],0);
 
 		//each proc adds to the queue
 		for (unsigned int i=0; i < npicks ; i++)

--- a/src/Methods/DirectForwardFlux.h
+++ b/src/Methods/DirectForwardFlux.h
@@ -58,10 +58,10 @@ namespace SSAGES
 		DirectForwardFlux(const MPI_Comm& world,
 		                  const MPI_Comm& comm, 
 		                  double ninterfaces, std::vector<double> interfaces,
-		                  unsigned int N0Target, std::vector<unsigned int> M,
+		                  unsigned int N0Target, unsigned int NLastSuccessful, std::vector<unsigned int> M,
 		                  bool initialFluxFlag, bool saveTrajectories, 
 		                  unsigned int currentInterface, std::string output_directory, unsigned int frequency)
-		: ForwardFlux(world, comm, ninterfaces, interfaces, N0Target, M, 
+		: ForwardFlux(world, comm, ninterfaces, interfaces, N0Target, NLastSuccessful, M, 
 		              initialFluxFlag, saveTrajectories, currentInterface, output_directory, frequency) {}
 
 		//! Post-integration hook.

--- a/src/Methods/ForwardFlux.cpp
+++ b/src/Methods/ForwardFlux.cpp
@@ -658,6 +658,7 @@ namespace SSAGES
 			throw BuildException({"The size of \"interfaces\" and \"trials\" must be equal to \"nInterfaces\". See documentation for more information"});
 
 		auto N0Target = json.get("N0Target", 1).asInt();
+		auto NLastSuccessful = json.get("NLastSuccessful", 1).asInt();
 		auto initialFluxFlag = json.get("computeInitialFlux", true).asBool();
 		auto saveTrajectories = json.get("saveTrajectories", true).asBool();
 		auto currentInterface = json.get("currentInterface", 0).asInt();
@@ -673,7 +674,7 @@ namespace SSAGES
 
 		if(flavor == "DirectForwardFlux")
 		{
-			return new DirectForwardFlux(world, comm, ninterfaces, interfaces, N0Target, M, initialFluxFlag, saveTrajectories, currentInterface, output_directory, freq);            	
+			return new DirectForwardFlux(world, comm, ninterfaces, interfaces, N0Target, NLastSuccessful, M, initialFluxFlag, saveTrajectories, currentInterface, output_directory, freq);            	
 		}
 		else 
 		{

--- a/src/Methods/ForwardFlux.h
+++ b/src/Methods/ForwardFlux.h
@@ -101,6 +101,9 @@ namespace SSAGES
         //! Number of configurations to store at lambda0, target
         unsigned int _N0Target;
 
+        //! Number of configurations stored at last achived interface, for restart
+        unsigned int _NLastSuccessful;
+
         //! Flux of trajectories out of state A. Denoted PhiA0 over h_A in Allen2009.
         double _fluxA0;
 
@@ -272,6 +275,7 @@ namespace SSAGES
 		 * \param ninterfaces Number of interfaces.
 		 * \param interfaces Vector of interfaces.
 		 * \param N0Target Required number of initial configurations.
+         * \param NLastSuccessful The number of stored configurations at last achieved interface.
 		 * \param M Vector of trials.
 		 * \param initialFluxFlag Flag for first step of this method.
 		 * \param saveTrajectories Flag to save flux trajectories.
@@ -284,10 +288,10 @@ namespace SSAGES
 		ForwardFlux(const MPI_Comm& world,
 		            const MPI_Comm& comm, 
 		            double ninterfaces, std::vector<double> interfaces,
-		            unsigned int N0Target, std::vector<unsigned int> M,
+		            unsigned int N0Target, unsigned int NLastSuccessful, std::vector<unsigned int> M,
 		            bool initialFluxFlag, bool saveTrajectories,
 		            unsigned int currentInterface, std::string output_directory, unsigned int frequency) : 
-		 Method(frequency, world, comm), _ninterfaces(ninterfaces), _interfaces(interfaces), _N0Target(N0Target), 
+		 Method(frequency, world, comm), _ninterfaces(ninterfaces), _interfaces(interfaces), _N0Target(N0Target), _NLastSuccessful(NLastSuccessful),
 		 _M(M), _initialFluxFlag(initialFluxFlag), _saveTrajectories(saveTrajectories), _current_interface(currentInterface),
 		 _output_directory(output_directory), _generator(1), iteration_(0) 
 		{
@@ -356,10 +360,10 @@ namespace SSAGES
 			std::normal_distribution<double> distribution(0,1);
 			for (unsigned int i = 0; i < _N0Target ; i++)
 			{
-				Lambda0ConfigLibrary[i].l = 0;
+				Lambda0ConfigLibrary[i].l = _current_interface;
 				Lambda0ConfigLibrary[i].n = i;
 				Lambda0ConfigLibrary[i].a = 0;
-				Lambda0ConfigLibrary[i].lprev = 0;
+				Lambda0ConfigLibrary[i].lprev = _current_interface;
 				Lambda0ConfigLibrary[i].nprev = i;
 				Lambda0ConfigLibrary[i].aprev = 0;
 				//FFSConfigID ffsconfig = Lambda0ConfigLibrary[i];

--- a/src/Methods/ForwardFlux.h
+++ b/src/Methods/ForwardFlux.h
@@ -353,9 +353,15 @@ namespace SSAGES
 				std::cerr << "\n";
 				MPI_Abort(world_, EXIT_FAILURE);
 			}
-
+        
 			// This is to generate an artificial Lambda0ConfigLibrary, Hadi's code does this for real
 			// THIS SHOULD BE SOMEWHERE ELSE!!! 
+
+			if (!_initialFluxFlag)
+			{
+                _N0Target = NLastSuccessful;
+			}
+
 			Lambda0ConfigLibrary.resize(_N0Target);
 			std::normal_distribution<double> distribution(0,1);
 			for (unsigned int i = 0; i < _N0Target ; i++)


### PR DESCRIPTION
This PR's aim is to fix a bug that arises during a restart calculation in the FFS method with "computeInitialFlux": false. This problem is mentioned by zheng001a in Issue 38. If I don't mistake, the reason is that the value _N[0] was used during the first initialization of the queue, which is not defined in this case. To avoid it I've introduced a new variable, NLastSuccessful, which stores the number of successful trial runs saved on the last surface reached.

In addition, trial runs always started with zeroth surface at restart. I've changed the way of generating Lambda0ConfigLibrary, it seems works well, but may be this is not the best way.

I'm newbie in programming but I hope these changes will be useful.
